### PR TITLE
Fixing broken twitter url.

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
       <div class="links">
         <ul>
           <li><a href="http://tech.gilt.com/jobs">Join the Gilt Tech Team</a></li>
-          <li><a href="http://tech.gilt.com/twitter">Follow us on Twitter</a></li>
+          <li><a href="http://twitter.com/gilttech">Follow us on Twitter</a></li>
           <li><a href="http://tech.gilt.com/api">Use the Public API</a></li>
           <li><a href="http://tech.gilt.com">Gilt Tech Blog</a></li>
           <li><a href="http://tech.gilt.com/ux">Gilt UX Blog</a></li>
@@ -54,7 +54,7 @@
       <div class="links">
         <ul>
           <li><a href="http://tech.gilt.com/jobs">Join the Gilt Tech Team</a></li>
-          <li><a href="http://tech.gilt.com/twitter">Follow us on Twitter</a></li>
+          <li><a href="http://twitter.com/gilttech">Follow us on Twitter</a></li>
           <li><a href="http://tech.gilt.com/api">Use the Public API</a></li>
           <li><a href="http://tech.gilt.com">Gilt Tech Blog</a></li>
           <li><a href="http://tech.gilt.com/ux">Gilt UX Blog</a></li>


### PR DESCRIPTION
- Was probably working before we moved the tech blog. Could probably update
  tech.gilt.com/twitter to redirect, but this seems more direct.